### PR TITLE
updated login-cookie name at thalia.de

### DIFF
--- a/tolinocloud.py
+++ b/tolinocloud.py
@@ -137,7 +137,7 @@ class TolinoCloud:
                     'login' : ''
                     }
              },
-            'login_cookie'     : 'JSESSIONID',
+            'login_cookie'     : 'OAUTH-JSESSIONID',
             'logout_url'       : 'https://www.thalia.de/shop/home/login/logout/',
             'reader_url'       : 'https://webreader.mytolino.com/library/index.html#/mybooks/titles',
             'register_url'     : 'https://bosh.pageplace.de/bosh/rest/v2/registerhw',


### PR DESCRIPTION
Login cookie name has changed for thalia.de
This might also be the same for thalia.at, but since I dont have an account there I can not check it and have only changed thalia.de for now.